### PR TITLE
Parallel utilities

### DIFF
--- a/system.go
+++ b/system.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// StopEtcd stops etcd on a specific host
+func StopEtcd(node TestbedNode) error {
+	log.Infof("Stopping etcd")
+	return node.RunCommand("pkill etcd && rm -rf /tmp/etcd")
+}
+
+// StartEtcd starts etcd on a specific host.
+func StartEtcd(node TestbedNode) error {
+	log.Infof("Starting etcd")
+
+	_, err := node.RunCommandBackground("nohup etcd -data-dir /tmp/etcd </dev/null &>>/tmp/etcd.log &")
+	log.Infof("Waiting for etcd to finish starting")
+	time.Sleep(10 * time.Millisecond)
+	return err
+}

--- a/vagrant.go
+++ b/vagrant.go
@@ -26,7 +26,7 @@ import (
 // Vagrant implements a vagrant based testbed
 type Vagrant struct {
 	expectedNodes int
-	nodes         []TestbedNode
+	nodes         map[string]TestbedNode
 }
 
 // Setup brings up a vagrant testbed
@@ -124,7 +124,7 @@ func (v *Vagrant) Setup(start bool, env string, numNodes int) error {
 		if node, err = NewVagrantNode(nodeName, port, privKeyFile); err != nil {
 			return err
 		}
-		v.nodes = append(v.nodes, TestbedNode(node))
+		v.nodes[node.GetName()] = TestbedNode(node)
 	}
 
 	return nil
@@ -143,11 +143,21 @@ func (v *Vagrant) Teardown() {
 			err, output)
 	}
 
-	v.nodes = []TestbedNode{}
+	v.nodes = map[string]TestbedNode{}
 	v.expectedNodes = 0
+}
+
+// GetNode obtains a node by name.
+func (v *Vagrant) GetNode(name string) TestbedNode {
+	return v.nodes[name]
 }
 
 // GetNodes returns the nodes in a vagrant setup
 func (v *Vagrant) GetNodes() []TestbedNode {
-	return v.nodes
+	var ret []TestbedNode
+	for _, value := range v.nodes {
+		ret = append(ret, value)
+	}
+
+	return ret
 }

--- a/vagrantnode.go
+++ b/vagrantnode.go
@@ -18,14 +18,16 @@ package utils
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 
 	"golang.org/x/crypto/ssh"
 )
 
 // VagrantNode implements a node in vagrant testbed
 type VagrantNode struct {
-	Name   string
-	client *ssh.Client
+	Name      string
+	primaryIP net.IP
+	client    *ssh.Client
 }
 
 //NewVagrantNode intializes a node in vagrant testbed


### PR DESCRIPTION
@mapuri PTAL

This adds parallel utilities which can potentially be used for the performance improvement of the netplugin tests. Before these changes, volplugin ran about 5 minutes for the systemtests, it takes less than 2 now.
