### PR TITLE
system.go: StartEtcd and StopEtcd now use systemd

### DIFF
--- a/system.go
+++ b/system.go
@@ -12,7 +12,7 @@ func StopEtcd(nodes []TestbedNode) error {
 	for _, node := range nodes {
 		log.Infof("Stopping etcd on node %s", node.GetName())
 
-		if err := node.RunCommand("sudo systemctl stop etcd; rm -rf /var/lib/etcd"); err != nil {
+		if err := node.RunCommand("sudo systemctl stop etcd"); err != nil {
 			return err
 		}
 

--- a/system.go
+++ b/system.go
@@ -1,23 +1,68 @@
 package utils
 
 import (
+	"fmt"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 // StopEtcd stops etcd on a specific host
-func StopEtcd(node TestbedNode) error {
-	log.Infof("Stopping etcd")
-	return node.RunCommand("pkill etcd && rm -rf /tmp/etcd")
+func StopEtcd(nodes []TestbedNode) error {
+	for _, node := range nodes {
+		log.Infof("Stopping etcd on node %s", node.GetName())
+
+		if err := node.RunCommand("sudo systemctl stop etcd; rm -rf /var/lib/etcd"); err != nil {
+			return err
+		}
+
+		times := 10
+
+		for {
+			if err := node.RunCommand("etcdctl member list"); err != nil {
+				break
+			}
+
+			times--
+
+			if times < 0 {
+				return fmt.Errorf("Timed out stopping etcd on %s", node.GetName())
+			}
+
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	return nil
+}
+
+func ClearEtcd(node TestbedNode) {
+	node.RunCommand("etcdctl ls --recursive / | xargs etcdctl rm --recursive")
 }
 
 // StartEtcd starts etcd on a specific host.
-func StartEtcd(node TestbedNode) error {
-	log.Infof("Starting etcd")
+func StartEtcd(nodes []TestbedNode) error {
+	for _, node := range nodes {
+		log.Infof("Starting etcd on %s", node.GetName())
+		times := 10
 
-	_, err := node.RunCommandBackground("nohup etcd -data-dir /tmp/etcd </dev/null &>>/tmp/etcd.log &")
-	log.Infof("Waiting for etcd to finish starting")
-	time.Sleep(10 * time.Millisecond)
-	return err
+		for {
+			// the error is not checked here because we will not successfully start
+			// etcd the second time we try, but want to retry if the first one fails.
+			node.RunCommand("sudo systemctl start etcd")
+
+			time.Sleep(1 * time.Second)
+
+			if err := node.RunCommand("etcdctl member list"); err == nil {
+				break
+			}
+
+			times--
+
+			if times < 0 {
+				return fmt.Errorf("Timed out starting etcd on %s", node.GetName())
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
I am already using this patch in volplugin master.

This drastically changes StartEtcd and StopEtcd, and introduces a new call: `ClearEtcd` which just deletes all the contents from etcd.

StartEtcd and StopEtcd walk a node list and changes the cluster that way. The changes are necessary because:
- etcd really wants to be started sequentially.
- With the supplied node list, testing applications can specify how to start and stop the cluster in order.
- cluster operations will wait until they succeed
